### PR TITLE
Update Spine 3.8 to work with Axmol v1 and v2

### DIFF
--- a/AttachmentVertices.h
+++ b/AttachmentVertices.h
@@ -30,7 +30,7 @@
 #ifndef SPINE_ATTACHMENTVERTICES_H_
 #define SPINE_ATTACHMENTVERTICES_H_
 
-#include "cocos2d.h"
+#include "axmol.h"
 
 #include <spine/spine.h>
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,4 +21,10 @@ endif()
 
 target_include_directories(${target_name} PUBLIC "runtime/include")
 
+get_target_property(AX_VERSION ${_AX_CORE_LIB} VERSION)
+if (AX_VERSION VERSION_GREATER_EQUAL 2.0)
+    ax_find_shaders(${CMAKE_CURRENT_LIST_DIR}/shaders SPINE_SHADER_SOURCES)
+    ax_target_compile_shaders(${target_name} FILES ${SPINE_SHADER_SOURCES} CUSTOM)    
+endif()
+
 setup_ax_extension_config(${target_name})

--- a/SkeletonAnimation.h
+++ b/SkeletonAnimation.h
@@ -32,7 +32,7 @@
 
 #include <spine/spine.h>
 #include <spine/spine-cocos2dx.h>
-#include "cocos2d.h"
+#include "axmol.h"
 
 namespace spine {
 

--- a/SkeletonBatch.cpp
+++ b/SkeletonBatch.cpp
@@ -38,9 +38,14 @@ USING_NS_AX;
 using std::max;
 #define INITIAL_SIZE (10000)
 
-#include "renderer/ccShaders.h"
+#if AX_VERSION >= 0X00020000
+#include "renderer/Shaders.h"
 #include "renderer/backend/Device.h"
 #include "renderer/backend/Types.h"
+#else
+#include "renderer/ccShaders.h"
+#include "renderer/backend/Device.h"
+#endif
 
 namespace spine {
 
@@ -88,7 +93,15 @@ backend::ProgramState* SkeletonBatch::updateCommandPipelinePS(SkeletonCommand* c
 {
 	auto& currentState = command->getPipelineDescriptor().programState;
 #if defined(AX_VERSION)
-	if(currentState == nullptr || currentState->getProgram() != programState->getProgram() || currentState->getUniformID() != programState->getUniformID()) {
+	if (currentState == nullptr 
+#if AX_VERSION >= 0X00020000
+		|| currentState->getBatchId() != programState->getBatchId()
+#else
+		|| currentState->getProgram() != programState->getProgram() || currentState->getUniformID() != programState->getUniformID()
+#endif
+)
+	{
+
 #else
 	if(currentState == nullptr || currentState->getProgram() != programState->getProgram()) {
 #endif

--- a/SkeletonRenderer.h
+++ b/SkeletonRenderer.h
@@ -30,7 +30,7 @@
 #ifndef SPINE_SKELETONRENDERER_H_
 #define SPINE_SKELETONRENDERER_H_
 
-#include "cocos2d.h"
+#include "axmol.h"
 #include <spine/spine.h>
 
 namespace spine {

--- a/SkeletonTwoColorBatch.cpp
+++ b/SkeletonTwoColorBatch.cpp
@@ -33,12 +33,24 @@
 #include <spine/Extension.h>
 #include <algorithm>
 #include <stddef.h> // offsetof
+#if AX_VERSION >= 0X00020000
+#include "base/Types.h"
+#include "base/Utils.h"
+
+#include "xxhash.h"
+#include "renderer/Shaders.h"
+#include "renderer/backend/Device.h"
+#else
 #include "base/ccTypes.h"
 #include "base/ccUtils.h"
 
 #include "xxhash.h"
 #include "renderer/ccShaders.h"
 #include "renderer/backend/Device.h"
+#endif
+
+
+
 
 USING_NS_AX;
 #define EVENT_AFTER_DRAW_RESET_POSITION "director_after_draw"
@@ -51,6 +63,7 @@ using std::max;
 
 namespace {
 
+#if AX_VERSION < 0X00020000
     const char* TWO_COLOR_TINT_VERTEX_SHADER = STRINGIFY(
     uniform mat4 u_PMatrix;
     attribute vec4 a_position;
@@ -93,6 +106,7 @@ namespace {
         gl_FragColor.rgb = ((texColor.a - 1.0) * v_dark.a + 1.0 - texColor.rgb) * v_dark.rgb + texColor.rgb * v_light.rgb;
     }
     );
+#endif
 
 
     std::shared_ptr<backend::ProgramState>  __twoColorProgramState = nullptr;
@@ -121,10 +135,15 @@ namespace {
         {
             return;
         }
+#if AX_VERSION < 0X00020000
         auto program = backend::Device::getInstance()->newProgram(TWO_COLOR_TINT_VERTEX_SHADER, TWO_COLOR_TINT_FRAGMENT_SHADER);
         auto* programState = new backend::ProgramState(program);
         program->release();
-
+#else
+        auto program = ProgramManager::getInstance()->loadProgram("custom/spineTwoColorTint_vs",
+            "custom/spineTwoColorTint_fs");
+        auto* programState = new backend::ProgramState(program);
+#endif
         updateProgramStateLayout(programState);
 
         __twoColorProgramState = std::shared_ptr<backend::ProgramState>(programState);

--- a/shaders/spineTwoColorTint.frag
+++ b/shaders/spineTwoColorTint.frag
@@ -1,0 +1,18 @@
+#version 310 es
+
+precision highp float;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+
+layout(location = COLOR0) in vec4 v_light;
+layout(location = COLOR1) in vec4 v_dark;
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+void main() {
+    vec4 texColor = texture(u_tex0, v_texCoord);
+    float alpha = texColor.a * v_light.a;
+    FragColor.a = alpha;
+    FragColor.rgb = ((texColor.a - 1.0) * v_dark.a + 1.0 - texColor.rgb) * v_dark.rgb + texColor.rgb * v_light.rgb;
+}

--- a/shaders/spineTwoColorTint.vert
+++ b/shaders/spineTwoColorTint.vert
@@ -1,0 +1,21 @@
+#version 310 es
+
+layout(location = POSITION) in vec4 a_position;
+layout(location = COLOR0) in vec4 a_color;
+layout(location = COLOR1) in vec4 a_color2;
+layout(location = TEXCOORD0) in vec2 a_texCoord;
+
+layout(location = COLOR0) out vec4 v_light;
+layout(location = COLOR1) out vec4 v_dark;
+layout(location = TEXCOORD0) out vec2 v_texCoord;
+
+layout(std140) uniform vs_ub {
+    mat4 u_PMatrix;
+};
+
+void main() {
+    v_light = a_color;
+    v_dark = a_color2;
+    v_texCoord = a_texCoord;
+    gl_Position = u_PMatrix * a_position;
+}


### PR DESCRIPTION
The Spine 3.8 runtime has been updated to work with both Axmol v1 and v2.